### PR TITLE
fix(text2token): 正负号转为加减号提升通用性

### DIFF
--- a/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/calculate.test.ts
+++ b/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/calculate.test.ts
@@ -5,35 +5,35 @@ import { CalcExpressionFactory } from './expressions';
 test('+-x/', () => {
   const factory = new CalcExpressionFactory();
 
-  expect(calculate(['1', '1', '+'], factory)).toBe(2);
-  expect(calculate(['1', '1', '+'], factory)).toBe(2);
-  expect(calculate(['1', '1', '-'], factory)).toBe(0);
-  expect(calculate(['1', '1', '*'], factory)).toBe(1);
-  expect(calculate(['1', '1', '/'], factory)).toBe(1);
+  expect(calculate(['1', '1', '+'], factory)).toBeCloseTo(2);
+  expect(calculate(['1', '1', '+'], factory)).toBeCloseTo(2);
+  expect(calculate(['1', '1', '-'], factory)).toBeCloseTo(0);
+  expect(calculate(['1', '1', '*'], factory)).toBeCloseTo(1);
+  expect(calculate(['1', '1', '/'], factory)).toBeCloseTo(1);
 
-  expect(calculate(['1', '2', '3', '+', '+'], factory)).toBe(6);
-  expect(calculate(['2', '4', '6', '+', '*'], factory)).toBe(20);
-  expect(calculate(['2', '4', '6', '+', '/'], factory)).toBe(0.2);
+  expect(calculate(['1', '2', '3', '+', '+'], factory)).toBeCloseTo(6);
+  expect(calculate(['2', '4', '6', '+', '*'], factory)).toBeCloseTo(20);
+  expect(calculate(['2', '4', '6', '+', '/'], factory)).toBeCloseTo(0.2);
 
-  expect(calculate(['1', '2', '3', '-', '-'], factory)).toBe(2);
-  expect(calculate(['2', '4', '6', '-', '*'], factory)).toBe(-4);
-  expect(calculate(['2', '4', '6', '-', '/'], factory)).toBe(-1);
+  expect(calculate(['1', '2', '3', '-', '-'], factory)).toBeCloseTo(2);
+  expect(calculate(['2', '4', '6', '-', '*'], factory)).toBeCloseTo(-4);
+  expect(calculate(['2', '4', '6', '-', '/'], factory)).toBeCloseTo(-1);
 });
 
 test('三角函数', () => {
   const factory = new CalcExpressionFactory();
 
-  expect(calculate(['30', 'sin'], factory)).toBe(0.49999999999999994);
-  expect(calculate(['60', 'cos'], factory)).toBe(0.5000000000000001);
-  expect(calculate(['45', 'tan'], factory)).toBe(0.9999999999999999);
+  expect(calculate(['30', 'sin'], factory)).toBeCloseTo(0.5);
+  expect(calculate(['60', 'cos'], factory)).toBeCloseTo(0.5);
+  expect(calculate(['45', 'tan'], factory)).toBeCloseTo(1.0);
 });
 
 test('复合模式', () => {
   const factory = new CalcExpressionFactory();
 
-  expect(calculate(['12', '30', 'sin', '/'], factory)).toBe(24.000000000000004);
-  expect(calculate(['60', 'cos', '5', '+'], factory)).toBe(5.5);
-  expect(calculate(['25', '20', '+', 'tan'], factory)).toBe(0.9999999999999999);
+  expect(calculate(['12', '30', 'sin', '/'], factory)).toBeCloseTo(24);
+  expect(calculate(['60', 'cos', '5', '+'], factory)).toBeCloseTo(5.5);
+  expect(calculate(['25', '20', '+', 'tan'], factory)).toBeCloseTo(1.0);
 });
 
 test('错误情况', () => {

--- a/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/calculator.test.ts
+++ b/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/calculator.test.ts
@@ -4,42 +4,57 @@ import { CalculatorImpl } from './calculator';
 test('+', () => {
   const calculator = new CalculatorImpl();
 
-  expect(calculator.calc('1+2')).toBe(3);
-  expect(calculator.calc('1+2+3')).toBe(6);
-  expect(calculator.calc('1 + 2')).toBe(3);
-  expect(calculator.calc(' 1+2')).toBe(3);
-  expect(calculator.calc('1+2 ')).toBe(3);
-  expect(calculator.calc('1+(-1)')).toBe(0);
+  expect(calculator.calc('1+2')).toBeCloseTo(3);
+  expect(calculator.calc('1+2+3')).toBeCloseTo(6);
+  expect(calculator.calc('1 + 2')).toBeCloseTo(3);
+  expect(calculator.calc(' 1+2')).toBeCloseTo(3);
+  expect(calculator.calc('1+2 ')).toBeCloseTo(3);
+  expect(calculator.calc('1+(-1)')).toBeCloseTo(0);
 });
 
 test('-', () => {
   const calculator = new CalculatorImpl();
 
-  expect(calculator.calc('1-2')).toBe(-1);
-  expect(calculator.calc('1-2-3')).toBe(-4);
-  expect(calculator.calc('1 - 2')).toBe(-1);
-  expect(calculator.calc(' 1-2')).toBe(-1);
-  expect(calculator.calc('1-2 ')).toBe(-1);
+  expect(calculator.calc('1-2')).toBeCloseTo(-1);
+  expect(calculator.calc('1-2-3')).toBeCloseTo(-4);
+  expect(calculator.calc('1 - 2')).toBeCloseTo(-1);
+  expect(calculator.calc(' 1-2')).toBeCloseTo(-1);
+  expect(calculator.calc('1-2 ')).toBeCloseTo(-1);
 });
 
 test('*', () => {
   const calculator = new CalculatorImpl();
 
-  expect(calculator.calc('1*2')).toBe(2);
-  expect(calculator.calc('1*2*3')).toBe(6);
-  expect(calculator.calc('1 * 2')).toBe(2);
-  expect(calculator.calc(' 1*2')).toBe(2);
-  expect(calculator.calc('1*2 ')).toBe(2);
+  expect(calculator.calc('1*2')).toBeCloseTo(2);
+  expect(calculator.calc('1*2*3')).toBeCloseTo(6);
+  expect(calculator.calc('1 * 2')).toBeCloseTo(2);
+  expect(calculator.calc(' 1*2')).toBeCloseTo(2);
+  expect(calculator.calc('1*2 ')).toBeCloseTo(2);
 });
 
 test('/', () => {
   const calculator = new CalculatorImpl();
 
-  expect(calculator.calc('1/2')).toBe(0.5);
-  expect(calculator.calc('1/2/3')).toBe(0.16666666666666666);
-  expect(calculator.calc('1 / 2')).toBe(0.5);
-  expect(calculator.calc(' 1/2')).toBe(0.5);
-  expect(calculator.calc('1/2 ')).toBe(0.5);
+  expect(calculator.calc('1/2')).toBeCloseTo(0.5);
+  expect(calculator.calc('1/2/3')).toBeCloseTo(0.16666666666666666);
+  expect(calculator.calc('1 / 2')).toBeCloseTo(0.5);
+  expect(calculator.calc(' 1/2')).toBeCloseTo(0.5);
+  expect(calculator.calc('1/2 ')).toBeCloseTo(0.5);
 
-  expect(calculator.calc('1/0')).toBe(Infinity);
+  expect(calculator.calc('1/0')).toBeCloseTo(Infinity);
+});
+
+test('sin/cos/tan', () => {
+  const calculator = new CalculatorImpl();
+
+  expect(calculator.calc('sin(0)')).toBeCloseTo(0);
+  expect(calculator.calc('cos(0)')).toBeCloseTo(1);
+  expect(calculator.calc('tan(0)')).toBeCloseTo(0);
+
+  expect(calculator.calc('-sin(30)')).toBeCloseTo(-0.5);
+  expect(calculator.calc('-cos(60)')).toBeCloseTo(-0.5);
+  expect(calculator.calc('-tan(45)')).toBeCloseTo(-1);
+
+  expect(calculator.calc('1 + sin(180)')).toBeCloseTo(1);
+  expect(calculator.calc('cos(90 - 30) * 3')).toBeCloseTo(1.5);
 });

--- a/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/expressions/binary-args-op-expression.test.ts
+++ b/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/expressions/binary-args-op-expression.test.ts
@@ -20,9 +20,9 @@ test('AddOpExpression', () => {
   const n2 = new NumberExpression('2');
   const n3 = new NumberExpression('3');
 
-  expect(new AddOpExpression(n1, n2).interpreter()).toBe(3);
-  expect(new AddOpExpression(n1, n3).interpreter()).toBe(4);
-  expect(new AddOpExpression(n2, n3).interpreter()).toBe(5);
+  expect(new AddOpExpression(n1, n2).interpreter()).toBeCloseTo(3);
+  expect(new AddOpExpression(n1, n3).interpreter()).toBeCloseTo(4);
+  expect(new AddOpExpression(n2, n3).interpreter()).toBeCloseTo(5);
 });
 
 test('SubOpExpression', () => {
@@ -30,9 +30,9 @@ test('SubOpExpression', () => {
   const n2 = new NumberExpression('2');
   const n3 = new NumberExpression('3');
 
-  expect(new SubOpExpression(n1, n2).interpreter()).toBe(-1);
-  expect(new SubOpExpression(n1, n3).interpreter()).toBe(-2);
-  expect(new SubOpExpression(n2, n3).interpreter()).toBe(-1);
+  expect(new SubOpExpression(n1, n2).interpreter()).toBeCloseTo(-1);
+  expect(new SubOpExpression(n1, n3).interpreter()).toBeCloseTo(-2);
+  expect(new SubOpExpression(n2, n3).interpreter()).toBeCloseTo(-1);
 });
 
 test('MulOpExpression', () => {
@@ -40,9 +40,9 @@ test('MulOpExpression', () => {
   const n2 = new NumberExpression('2');
   const n3 = new NumberExpression('3');
 
-  expect(new MulOpExpression(n1, n2).interpreter()).toBe(2);
-  expect(new MulOpExpression(n1, n3).interpreter()).toBe(3);
-  expect(new MulOpExpression(n2, n3).interpreter()).toBe(6);
+  expect(new MulOpExpression(n1, n2).interpreter()).toBeCloseTo(2);
+  expect(new MulOpExpression(n1, n3).interpreter()).toBeCloseTo(3);
+  expect(new MulOpExpression(n2, n3).interpreter()).toBeCloseTo(6);
 });
 
 test('DivOpExpression', () => {
@@ -50,7 +50,7 @@ test('DivOpExpression', () => {
   const n2 = new NumberExpression('2');
   const n3 = new NumberExpression('3');
 
-  expect(new DivOpExpression(n1, n2).interpreter()).toBe(1 / 2);
-  expect(new DivOpExpression(n1, n3).interpreter()).toBe(1 / 3);
-  expect(new DivOpExpression(n2, n3).interpreter()).toBe(2 / 3);
+  expect(new DivOpExpression(n1, n2).interpreter()).toBeCloseTo(1 / 2);
+  expect(new DivOpExpression(n1, n3).interpreter()).toBeCloseTo(1 / 3);
+  expect(new DivOpExpression(n2, n3).interpreter()).toBeCloseTo(2 / 3);
 });

--- a/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/expressions/number-expression.test.ts
+++ b/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/expressions/number-expression.test.ts
@@ -8,7 +8,7 @@ test('消费表达式数量', () => {
 test('NumberExpression', () => {
   Array.from({ length: 10 }, (_, i): number => Math.random() * 10 ** i).forEach(
     (value): void => {
-      expect(new NumberExpression(`${value}`).interpreter()).toBe(value);
+      expect(new NumberExpression(`${value}`).interpreter()).toBeCloseTo(value);
     },
   );
 });

--- a/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/expressions/single-args-op-expression.test.ts
+++ b/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/expressions/single-args-op-expression.test.ts
@@ -18,7 +18,7 @@ test('SinOpExpression', () => {
   const testFn = (num: number): void => {
     const n = new NumberExpression(num.toString());
     const expected = Math.sin((num / 180) * Math.PI);
-    expect(new SinOpExpression(n).interpreter()).toBe(expected);
+    expect(new SinOpExpression(n).interpreter()).toBeCloseTo(expected);
   };
 
   testFn(0);
@@ -31,7 +31,7 @@ test('CosOpExpression', () => {
   const testFn = (num: number): void => {
     const n = new NumberExpression(num.toString());
     const expected = Math.cos((num / 180) * Math.PI);
-    expect(new CosOpExpression(n).interpreter()).toBe(expected);
+    expect(new CosOpExpression(n).interpreter()).toBeCloseTo(expected);
   };
 
   testFn(0);
@@ -44,7 +44,7 @@ test('TanOpExpression', () => {
   const testFn = (num: number): void => {
     const n = new NumberExpression(num.toString());
     const expected = Math.tan((num / 180) * Math.PI);
-    expect(new TanOpExpression(n).interpreter()).toBe(expected);
+    expect(new TanOpExpression(n).interpreter()).toBeCloseTo(expected);
   };
 
   testFn(0);

--- a/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/text2token.test.ts
+++ b/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/text2token.test.ts
@@ -33,7 +33,20 @@ test('三角函数', () => {
 });
 
 test('含有正负号', () => {
-  expect(text2token('-1')).toEqual(['-1']);
-  expect(text2token('-1+2')).toEqual(['-1', '+', '2']);
-  expect(text2token('-1+(-2)')).toEqual(['-1', '+', '(', '-2', ')']);
+  expect(text2token('-1')).toEqual(['0', '-', '1']);
+  expect(text2token('-1+2')).toEqual(['0', '-', '1', '+', '2']);
+  expect(text2token('-1+(-2)')).toEqual([
+    '0',
+    '-',
+    '1',
+    '+',
+    '(',
+    '0',
+    '-',
+    '2',
+    ')',
+  ]);
+
+  expect(text2token('+1')).toEqual(['0', '+', '1']);
+  expect(text2token('1+(+2)')).toEqual(['1', '+', '(', '0', '+', '2', ')']);
 });

--- a/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/text2token.ts
+++ b/examples/design-patterns/src/patterns/interpreter-pattern/calculator.impl/text2token.ts
@@ -24,14 +24,16 @@ class CharCollector {
 
 /**
  * 将一个中缀表达式字符串转为中缀表达式数组
+ *
+ * 注意：正负号与加减号相似，所以将所有的正负号前面进行补零处理
+ *
  * @param text  - 中缀表达式字符串，例：1 + 2 * (3 / 4)
  * @returns token 中缀表达式数组
  */
 export const text2token = (text: string): string[] => {
   const result: string[] = [];
 
-  const numberCollector = new CharCollector();
-  const letterCollector = new CharCollector();
+  const collector = new CharCollector();
 
   let prevNonSpaceChar: string | undefined;
 
@@ -41,7 +43,10 @@ export const text2token = (text: string): string[] => {
         break;
       case isDigit(char):
       case isDot(char):
-        numberCollector.add(char);
+        collector.add(char); // 数字都是连续的
+        break;
+      case isLetter(char):
+        collector.add(char); // 字母都是连续的
         break;
       case isNegativeSign(char):
       case isPositiveSign(char):
@@ -49,21 +54,20 @@ export const text2token = (text: string): string[] => {
          *  处理 +、- 作为正负号的情况
          *    第一种情况：-1 + 2
          *    第二种情况：1 + (-2)
+         *
+         *  使用“补零”的矫正为将正负矫正为加减
          */
         if (!prevNonSpaceChar || isOpenBracket(prevNonSpaceChar)) {
-          numberCollector.add(char);
+          result.push('0');
+          result.push(char);
         } else {
-          result.push(numberCollector.consume());
-          result.push(letterCollector.consume());
+          result.push(collector.consume());
           result.push(char);
         }
         break;
-      case isLetter(char):
-        letterCollector.add(char);
-        break;
+
       default:
-        result.push(numberCollector.consume());
-        result.push(letterCollector.consume());
+        result.push(collector.consume());
         result.push(char);
     }
 
@@ -72,8 +76,7 @@ export const text2token = (text: string): string[] => {
     }
   }
 
-  result.push(numberCollector.consume());
-  result.push(letterCollector.consume());
+  result.push(collector.consume());
 
   return result.filter((str) => str.length > 0);
 };


### PR DESCRIPTION
由于-tan(20) 这种被认为是一种非法的表达式,
而如果在转为中缀表达式时,会产生歧义导致抛出错误,而且解释器也要单独,使后续流程简单化,在文本解析时直接通过前置补零的形式,将正负号转为加减号,来简化操作

fix #44 